### PR TITLE
iOS 13 で詳細画面に遷移したらアプリが落ちるのを修正

### DIFF
--- a/StudyGroupEventFetcherForSwiftUI/Views/EventDetail/EventDetailButtonView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/EventDetail/EventDetailButtonView.swift
@@ -11,27 +11,41 @@ import SwiftUI
 struct EventDetailButtonView: View {
 
     var eventUrl: String
-    @State private var showModal = false
 
     var body: some View {
-        Group {
-            if #available(iOS 14.0, *) {
-                Link(destination: URL(string: self.eventUrl)!) {
-                    EventDetailButtonTitleView()
-                }
-            } else {
-                Button(action: {
-                    self.showModal.toggle()
-                }) {
-                    EventDetailButtonTitleView()
-                }
-                .sheet(isPresented: $showModal) {
-                    SafariView(url: URL(string: self.eventUrl))
-                        .edgesIgnoringSafeArea(.bottom)
-                }
-            }
+        if #available(iOS 14.0, *) {
+            return AnyView(EventLinkView(eventUrl: self.eventUrl))
+        } else {
+            return AnyView(EventLinkButton(eventUrl: self.eventUrl))
         }
-        .padding(20.0)
+    }
+}
+
+/// iOS 14 で Link を使って Safari を開くボタン
+@available(iOS 14.0, *)
+struct EventLinkView: View {
+    var eventUrl: String
+    var body: some View {
+        Link(destination: URL(string: self.eventUrl)!) {
+            EventDetailButtonTitleView()
+        }.padding(20.0)
+    }
+}
+
+/// iOS 13 で SafariVC を開くボタン
+struct EventLinkButton: View {
+    var eventUrl: String
+    @State private var showModal = false
+    var body: some View {
+        Button(action: {
+            self.showModal.toggle()
+        }) {
+            EventDetailButtonTitleView()
+        }
+        .sheet(isPresented: $showModal) {
+            SafariView(url: URL(string: self.eventUrl))
+                .edgesIgnoringSafeArea(.bottom)
+        }.padding(20.0)
     }
 }
 


### PR DESCRIPTION
## Contents

* iOS 13 で詳細画面に遷移したらアプリが落ちるのを修正

Xcode 12 正式版で治る可能性🤔

FYI
https://developer.apple.com/forums/thread/118172