### PR TITLE
ハッシュタグに角丸のボーダーをつける

### DIFF
--- a/StudyGroupEventFetcherForSwiftUI/Views/TopEventList/EventRowView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/TopEventList/EventRowView.swift
@@ -35,6 +35,13 @@ struct EventRowView: View {
                 Text("#" + eventData.hashTag)
                     .foregroundColor(.blue)
                     .font(.caption)
+                    .bold()
+                    .padding(.horizontal, 8.0)
+                    .padding(.vertical, 4.0)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20.0)
+                            .stroke(Color.blue, lineWidth: 1.0)
+                )
             }
             .padding(.bottom, 8.0)
         }


### PR DESCRIPTION
## 内容

* ハッシュタグに角丸のボーダーをつける

## スクリーンショット

|ライトモード|ダークモード|
|:--:|:--:|
|![IMG_0890](https://user-images.githubusercontent.com/8732417/86439648-ef17e300-bd43-11ea-95f5-60169b2bde2a.PNG)|![IMG_0891](https://user-images.githubusercontent.com/8732417/86439661-f2ab6a00-bd43-11ea-8a20-18d9c516e8d1.PNG)|