### PR TITLE
Changed the maximum number of event data to the maximum(100)

### DIFF
--- a/StudyGroupEventFetcherForSwiftUI/Other/StudyGroupEventFetcher.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Other/StudyGroupEventFetcher.swift
@@ -11,7 +11,7 @@ import Foundation
 class StudyGroupEventFetcher {
 
     // connpass's event search API
-    private let urlLink = "https://connpass.com/api/v1/event/?keyword=YUMEMI.swift"
+    private let urlLink = "https://connpass.com/api/v1/event/?keyword=YUMEMI.swift&count=100"
 
     func fetchEventData(completion: @escaping ([Event]) -> Void) {
         URLSession.shared.dataTask(with: URL(string: urlLink)!) { (data, response, error) in


### PR DESCRIPTION
## Details

* Changed the maximum number of event data to the maximum(100)

YUMEMI.swift was held 11 times. More will be held in February. 
The default number of acquisitions in the event search API of connpass is 10, and up to 100 can be acquired.