### PR TITLE
#29 SwiftUIでマップ実装するように変更

### DIFF
--- a/StudyGroupEventFetcherForSwiftUI.xcodeproj/project.pbxproj
+++ b/StudyGroupEventFetcherForSwiftUI.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		FD794B6D2462D35B00C000CD /* EventDetailMapButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD794B6C2462D35B00C000CD /* EventDetailMapButtonView.swift */; };
 		FD9E6FD6294D61B000979FFF /* LoadingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9E6FD5294D61B000979FFF /* LoadingViewModifier.swift */; };
 		FD9E6FDE29504D5A00979FFF /* PinItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9E6FDD29504D5A00979FFF /* PinItem.swift */; };
+		FD9E6FE029504FE000979FFF /* NewMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9E6FDF29504FE000979FFF /* NewMapView.swift */; };
 		FD9EB13B236C33EE00DD6367 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9EB13A236C33EE00DD6367 /* AppDelegate.swift */; };
 		FD9EB13D236C33EE00DD6367 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9EB13C236C33EE00DD6367 /* SceneDelegate.swift */; };
 		FD9EB141236C33EF00DD6367 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD9EB140236C33EF00DD6367 /* Assets.xcassets */; };
@@ -64,6 +65,7 @@
 		FD794B6C2462D35B00C000CD /* EventDetailMapButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailMapButtonView.swift; sourceTree = "<group>"; };
 		FD9E6FD5294D61B000979FFF /* LoadingViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewModifier.swift; sourceTree = "<group>"; };
 		FD9E6FDD29504D5A00979FFF /* PinItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinItem.swift; sourceTree = "<group>"; };
+		FD9E6FDF29504FE000979FFF /* NewMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMapView.swift; sourceTree = "<group>"; };
 		FD9EB137236C33EE00DD6367 /* StudyGroupEventFetcherForSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StudyGroupEventFetcherForSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD9EB13A236C33EE00DD6367 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD9EB13C236C33EE00DD6367 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 			isa = PBXGroup;
 			children = (
 				FD50073823AFC2AC00C369EF /* MapView.swift */,
+				FD9E6FDF29504FE000979FFF /* NewMapView.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -401,6 +404,7 @@
 				FD794B6D2462D35B00C000CD /* EventDetailMapButtonView.swift in Sources */,
 				FD0506DC2371282C003260B9 /* SafariView.swift in Sources */,
 				FD9EB13D236C33EE00DD6367 /* SceneDelegate.swift in Sources */,
+				FD9E6FE029504FE000979FFF /* NewMapView.swift in Sources */,
 				FD0506D3236C471E003260B9 /* Event.swift in Sources */,
 				FDA2705C24A7873A009A8505 /* EventLabelView.swift in Sources */,
 				FD0506DA23712219003260B9 /* EventDetailView.swift in Sources */,

--- a/StudyGroupEventFetcherForSwiftUI.xcodeproj/project.pbxproj
+++ b/StudyGroupEventFetcherForSwiftUI.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		FD525C65237133AE00F9C171 /* StudyGroupEventFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD525C64237133AE00F9C171 /* StudyGroupEventFetcher.swift */; };
 		FD794B6D2462D35B00C000CD /* EventDetailMapButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD794B6C2462D35B00C000CD /* EventDetailMapButtonView.swift */; };
 		FD9E6FD6294D61B000979FFF /* LoadingViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9E6FD5294D61B000979FFF /* LoadingViewModifier.swift */; };
+		FD9E6FDE29504D5A00979FFF /* PinItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9E6FDD29504D5A00979FFF /* PinItem.swift */; };
 		FD9EB13B236C33EE00DD6367 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9EB13A236C33EE00DD6367 /* AppDelegate.swift */; };
 		FD9EB13D236C33EE00DD6367 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9EB13C236C33EE00DD6367 /* SceneDelegate.swift */; };
 		FD9EB141236C33EF00DD6367 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FD9EB140236C33EF00DD6367 /* Assets.xcassets */; };
@@ -62,6 +63,7 @@
 		FD525C64237133AE00F9C171 /* StudyGroupEventFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGroupEventFetcher.swift; sourceTree = "<group>"; };
 		FD794B6C2462D35B00C000CD /* EventDetailMapButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailMapButtonView.swift; sourceTree = "<group>"; };
 		FD9E6FD5294D61B000979FFF /* LoadingViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewModifier.swift; sourceTree = "<group>"; };
+		FD9E6FDD29504D5A00979FFF /* PinItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinItem.swift; sourceTree = "<group>"; };
 		FD9EB137236C33EE00DD6367 /* StudyGroupEventFetcherForSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StudyGroupEventFetcherForSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD9EB13A236C33EE00DD6367 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FD9EB13C236C33EE00DD6367 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 			children = (
 				FD0506D0236C46A4003260B9 /* StudyGroup.swift */,
 				FD0506D2236C471E003260B9 /* Event.swift */,
+				FD9E6FDD29504D5A00979FFF /* PinItem.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FDF7EB90244B2B3000BF1A6E /* EventDetailButtonView.swift in Sources */,
+				FD9E6FDE29504D5A00979FFF /* PinItem.swift in Sources */,
 				FD0506D8236C4FA5003260B9 /* EventRowView.swift in Sources */,
 				FD9EB13B236C33EE00DD6367 /* AppDelegate.swift in Sources */,
 				FDAE1B78237173C900217BD1 /* StudyGroupDateFormatter.swift in Sources */,

--- a/StudyGroupEventFetcherForSwiftUI/Model/PinItem.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Model/PinItem.swift
@@ -1,0 +1,15 @@
+//
+//  PinItem.swift
+//  StudyGroupEventFetcherForSwiftUI
+//
+//  Created by Takuya Aso on 2022/12/19.
+//  Copyright © 2022 Takuya Aso. All rights reserved.
+//
+
+import Foundation
+import MapKit
+
+struct PinItem: Identifiable {
+    let id = UUID()
+    let coordinate: CLLocationCoordinate2D
+}

--- a/StudyGroupEventFetcherForSwiftUI/Views/EventDetail/EventDetailView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/EventDetail/EventDetailView.swift
@@ -17,8 +17,9 @@ struct EventDetailView: View {
             VStack(alignment: .leading) {
                 // MapView Part
                 ZStack(alignment: .bottomTrailing) {
-                    MapView(eventData: self.eventData, zoomValue: $zoomValue)
+                    NewMapView(eventData: eventData)
                         .frame(height: 300.0)
+
                     EventDetailMapButtonView(zoomValue: $zoomValue)
                         .padding(.bottom, 24.0)
                         .padding(.trailing, 12.0)

--- a/StudyGroupEventFetcherForSwiftUI/Views/EventDetail/EventDetailView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/EventDetail/EventDetailView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct EventDetailView: View {
-    var eventData: Event    // From ListView(静的モデル)
+    let eventData: Event    // From ListView(静的モデル)
     @State private var zoomValue = 0.01
 
     var body: some View {
@@ -17,8 +17,11 @@ struct EventDetailView: View {
             VStack(alignment: .leading) {
                 // MapView Part
                 ZStack(alignment: .bottomTrailing) {
-                    NewMapView(eventData: eventData)
-                        .frame(height: 300.0)
+                    NewMapView(
+                        eventData: eventData,
+                        zoomValue: $zoomValue
+                    )
+                    .frame(height: 300.0)
 
                     EventDetailMapButtonView(zoomValue: $zoomValue)
                         .padding(.bottom, 24.0)

--- a/StudyGroupEventFetcherForSwiftUI/Views/Map/NewMapView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/Map/NewMapView.swift
@@ -1,0 +1,61 @@
+//
+//  NewMapView.swift
+//  StudyGroupEventFetcherForSwiftUI
+//
+//  Created by Takuya Aso on 2022/12/19.
+//  Copyright © 2022 Takuya Aso. All rights reserved.
+//
+
+import SwiftUI
+import MapKit
+
+struct NewMapView: View {
+    // リスト画面から渡ってくる勉強会情報
+    let eventData: Event
+
+    @State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 35.6816005869028, longitude: 139.76595878344898), span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
+
+    var body: some View {
+        Map(
+            coordinateRegion: $region,
+            annotationItems: generatePinItem()) { item in
+                MapMarker(coordinate: item.coordinate)
+            }
+        .onAppear {
+            setTargetRegion()
+        }
+    }
+}
+
+extension NewMapView {
+    /// アノテーション用のデータを生成
+    private func generatePinItem() -> [PinItem] {
+        guard let latitude = eventData.lat,
+              let latValue = Double(latitude),
+              let longitude = eventData.lon,
+              let lonValue = Double(longitude) else {
+            return []
+        }
+        return [PinItem(coordinate: CLLocationCoordinate2D(latitude: latValue, longitude: lonValue))]
+    }
+
+    /// 表示時にマップの中央を会場の場所にする
+    private func setTargetRegion() {
+        guard let latitude = eventData.lat,
+              let latValue = Double(latitude),
+              let longitude = eventData.lon,
+              let lonValue = Double(longitude) else {
+            // オンラインなどで緯度経度の情報がnilの場合広域にしておく
+            region.span = MKCoordinateSpan(latitudeDelta: 30, longitudeDelta: 30)
+            return
+        }
+        // マップの中央を会場に
+        region.center = CLLocationCoordinate2D(latitude: latValue, longitude: lonValue)
+    }
+}
+
+struct NewMapView_Previews: PreviewProvider {
+    static var previews: some View {
+        NewMapView(eventData: mockEventsData[0])
+    }
+}

--- a/StudyGroupEventFetcherForSwiftUI/Views/Map/NewMapView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/Map/NewMapView.swift
@@ -12,6 +12,7 @@ import MapKit
 struct NewMapView: View {
     // リスト画面から渡ってくる勉強会情報
     let eventData: Event
+    @Binding var zoomValue: CLLocationDegrees
 
     @State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 35.6816005869028, longitude: 139.76595878344898), span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
 
@@ -23,6 +24,9 @@ struct NewMapView: View {
             }
         .onAppear {
             setTargetRegion()
+        }
+        .onChange(of: zoomValue) { newValue in
+            region.span = MKCoordinateSpan(latitudeDelta: zoomValue, longitudeDelta: zoomValue)
         }
     }
 }
@@ -56,6 +60,6 @@ extension NewMapView {
 
 struct NewMapView_Previews: PreviewProvider {
     static var previews: some View {
-        NewMapView(eventData: mockEventsData[0])
+        NewMapView(eventData: mockEventsData[0], zoomValue: .constant(0.01))
     }
 }

--- a/StudyGroupEventFetcherForSwiftUI/Views/Map/NewMapView.swift
+++ b/StudyGroupEventFetcherForSwiftUI/Views/Map/NewMapView.swift
@@ -12,6 +12,7 @@ import MapKit
 struct NewMapView: View {
     // リスト画面から渡ってくる勉強会情報
     let eventData: Event
+    // 詳細画面のマップの右下の+ - ボタンで変わるズームの値
     @Binding var zoomValue: CLLocationDegrees
 
     @State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 35.6816005869028, longitude: 139.76595878344898), span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
@@ -26,6 +27,7 @@ struct NewMapView: View {
             setTargetRegion()
         }
         .onChange(of: zoomValue) { newValue in
+            // + - ボタンでズームの値が変わるのでその変化を検知してマップの拡大縮小を行う
             region.span = MKCoordinateSpan(latitudeDelta: zoomValue, longitudeDelta: zoomValue)
         }
     }
@@ -49,7 +51,7 @@ extension NewMapView {
               let latValue = Double(latitude),
               let longitude = eventData.lon,
               let lonValue = Double(longitude) else {
-            // オンラインなどで緯度経度の情報がnilの場合広域にしておく
+            // オンライン開催などで緯度経度の情報がnilの場合広域にしておく
             region.span = MKCoordinateSpan(latitudeDelta: 30, longitudeDelta: 30)
             return
         }


### PR DESCRIPTION
## 内容

* Map を `MKMapView` から SwiftUI の Map を使うように変更

## ScreenShot

### 会場の緯度経度が取得できる場合

https://user-images.githubusercontent.com/8732417/208669073-f66ae8f2-c05b-4d93-af01-488c9746e281.mp4

### オンライン開催などで緯度経度がnilになっている場合

<img width="488" alt="スクリーンショット 2022-12-20 21 37 06" src="https://user-images.githubusercontent.com/8732417/208669100-dc475c48-6397-4fdc-8468-b37d68eb3bd8.png">
